### PR TITLE
-lEsay is redundant to using -E

### DIFF
--- a/perlsecret.pod
+++ b/perlsecret.pod
@@ -171,7 +171,7 @@ Perl code (as shown by using the C<B::Deparse> module):
 This operator is basically a shorter C<scalar> (shaves 4 characters!)
 using the same idea as the secret bang bang operator.
 
-    $ perl -lEsay~~localtime
+    $ perl -Esay~~localtime
     Tue Mar 13 19:53:25 2012
 
 The inchworm looks very much like the smart-match operator introduced


### PR DESCRIPTION
Since we're using the say function there's no reason to specify -l, which would add newlines to print().
