### PR TITLE
Fix Enterprise example.

### DIFF
--- a/perlsecret.pod
+++ b/perlsecret.pod
@@ -575,7 +575,7 @@ match the condition, in a single statement:
        ('apples'   )x!! ( $cupboard{apples} < 2 ),
        ('bananas'  )x!! ( $cupboard{bananas} < 2 ),
        ('cherries' )x!! ( $cupboard{cherries} < 20 ),
-       ('gin'      )x!! $cupboard{tonic},
+       ('tonic'    )x!! $cupboard{gin},
     );
 
 This operator is a container, which means the Enterprise can have a


### PR DESCRIPTION
Order of 'gin' and 'tonic' was reversed in second part of example.
