### PR TITLE
A few doc patches

### DIFF
--- a/lib/perlsecret.pod
+++ b/lib/perlsecret.pod
@@ -639,6 +639,8 @@ This constant has the value C<0>.
 Discovered by Rafaël Garcia-Suarez, 2009.
 
 Under Unix, will be equal to the real user home directory (by using C<glob>).
+On Win32 it will expand to C<$ENV{HOME}> if it is set (which is quite uncommon)
+or return C<'~'> else.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
- hyperlink `use integer` to the [integer](https://metacpan.org/module/integer) module doc
- `<~>` on Win32
