### PR TITLE
Fix typos

### DIFF
--- a/lib/perlsecret.pod
+++ b/lib/perlsecret.pod
@@ -221,7 +221,7 @@ named by Lorenzo Taviani.
 The I<Maori farewell> is a simili-C<BEGIN> block for one-liners.
 
 It exploits the B<-M> option for loading modules, and passes a number
-to it (therefore runnning the C<use VERSION> form). The code after the
+to it (therefore running the C<use VERSION> form). The code after the
 semicolon is inserted before the loop created by the C<-p> and C<-n>
 options.
 
@@ -248,7 +248,7 @@ the implicit loop that is created:
     }
 
 Note that the important item in the Maori farewell is the semicolon that
-follows the "module" name. In fact, the Moari farewell can be used with
+follows the "module" name. In fact, the Maori farewell can be used with
 any module loaded using the B<-M> option:
 
     $ perl -M"POSIX;print POSIX::strftime'%X',localtime" -lpe 's/foo/bar/'
@@ -494,7 +494,7 @@ assign values from the right-hand side to the variables inside it.
 In some cases, the full goatse is not needed, because there is no need
 to store the value in a variable. The side-effect of list assignment in
 scalar context can be obtained with a I<right-handed goatse> (C<()=>)
-used in a scalar context provided by some other mean than assignement
+used in a scalar context provided by some other mean than assignment
 to a scalar.
 For example:
 


### PR DESCRIPTION
I've noticed a typo while reading about the Maori farewell operator, and decided to send a PR about it. I've found another two while fixing the first, so I'm sending all of them combined.

ps.: English is not my native language, so please carefully proofread them before merging. I'm happy to update the PR if needed.