### PR TITLE
Flag section links as such

### DIFF
--- a/lib/perlsecret.pod
+++ b/lib/perlsecret.pod
@@ -767,7 +767,7 @@ This operator is a container, which means the Enterprise can have a
 large crew.
 
 The Enterprise is simply a list repetition operator C<< ()x >>
-followed by a boolean (see the L<Bang bang> operator above) which will be
+followed by a boolean (see the L</Bang bang> operator above) which will be
 interpreted as 1 or 0 in a numeric context.
 Note that the expression on the left is always evaluated, regardless of
 the state of the condition.
@@ -791,8 +791,8 @@ It simply makes the boolean false into the C<0> numeric value.
 
 Proposed by Daniel Bruder, 2014.
 
-This operator is a combination of the L<Inchworm> and L<Bang bang> operators.
-This is a simpler to type synonym for L<Key to the truth>, which makes the
+This operator is a combination of the L</Inchworm> and L</Bang bang> operators.
+This is a simpler to type synonym for L</Key to the truth>, which makes the
 boolean false into the C<0> numeric value.
 
     my $true  = ~~!! 'a string';    # now 1
@@ -828,7 +828,7 @@ just like the famous comedy duo.
 
 Proposed by Damien Krotkine, 2014.
 
-This operator works exactly like the L<Abbott and Costello>, except
+This operator works exactly like the L</Abbott and Costello>, except
 that it only makes C<undef> disappear in list context.
 
 This operator only works in Perl versions above 5.10.


### PR DESCRIPTION
Previously pod2html (and MetaCPAN) were making bad links for "Inchworm". Other links updated to be consistent.

See the "Inchworm" link on https://metacpan.org/dist/perlsecret/view/lib/perlsecret.pod#Serpent-of-truth